### PR TITLE
Metric Acceptation Ranges CRUD + small fixes

### DIFF
--- a/src/api/metricAcceptationRanges/MetricAcceptationRangesService.ts
+++ b/src/api/metricAcceptationRanges/MetricAcceptationRangesService.ts
@@ -1,0 +1,53 @@
+import { API } from "../../config/api";
+import {
+  GridParams,
+  transformGridParamsToFetchGridParams,
+} from "../../helpers/grid-helper";
+import FetchService from "../shared/FetchService";
+import { PaginatedList } from "../shared/models";
+import {
+  IMetricAcceptationRange,
+  MetricAcceptationRangeAddType,
+  MetricAcceptationRangeUpdateType,
+} from "./models";
+
+class MetricAcceptationRangesService {
+  static async fetchList(
+    gridParams: GridParams
+  ): Promise<PaginatedList<IMetricAcceptationRange>> {
+    return await FetchService.get<PaginatedList<IMetricAcceptationRange>>({
+      url: `${API.METRIC_ACCEPTATION_RANGES}`,
+      gridParams: transformGridParamsToFetchGridParams(gridParams),
+    });
+  }
+  static async fetchOne(id: string): Promise<IMetricAcceptationRange> {
+    return await FetchService.get<IMetricAcceptationRange>({
+      url: `${API.METRIC_ACCEPTATION_RANGES}/${id}`,
+    });
+  }
+
+  static async add(entity: MetricAcceptationRangeAddType): Promise<number> {
+    return await FetchService.post<number>({
+      url: API.METRIC_ACCEPTATION_RANGES,
+      body: entity,
+    });
+  }
+
+  static async update(
+    id: string,
+    entity: MetricAcceptationRangeUpdateType
+  ): Promise<void> {
+    await FetchService.put({
+      url: `${API.METRIC_ACCEPTATION_RANGES}/${id}`,
+      body: entity,
+    });
+  }
+
+  static async delete(id: string): Promise<void> {
+    await FetchService.delete({
+      url: `${API.METRIC_ACCEPTATION_RANGES}/${id}`,
+    });
+  }
+}
+
+export default MetricAcceptationRangesService;

--- a/src/api/metricAcceptationRanges/models.ts
+++ b/src/api/metricAcceptationRanges/models.ts
@@ -1,0 +1,23 @@
+export interface IMetricAcceptationRange {
+  metricAcceptationRangeId: number;
+  name: string;
+  startValue: number;
+  endValue: number;
+  createdAt?: string;
+  metricTypeCode: string;
+  metricTypeDescription?: string;
+}
+
+export type MetricAcceptationRangeAddType = Pick<
+  IMetricAcceptationRange,
+  "name" | "startValue" | "endValue" | "metricTypeCode"
+>;
+
+export type MetricAcceptationRangeUpdateType = Pick<
+  IMetricAcceptationRange,
+  | "metricAcceptationRangeId"
+  | "name"
+  | "startValue"
+  | "endValue"
+  | "metricTypeCode"
+>;

--- a/src/api/metricTypes/MetricTypesService.ts
+++ b/src/api/metricTypes/MetricTypesService.ts
@@ -1,0 +1,20 @@
+import { API } from "../../config/api";
+import FetchService from "../shared/FetchService";
+import { IMetricType, MetricTypeUpdateType } from "./models";
+
+class MetricTypesService {
+  static async fetchAll(): Promise<IMetricType[]> {
+    return FetchService.get({
+      url: `${API.METRIC_TYPES}/all`,
+    });
+  }
+
+  static async update(id: string, entity: MetricTypeUpdateType): Promise<void> {
+    await FetchService.put({
+      url: `${API.METRIC_TYPES}/${id}`,
+      body: entity,
+    });
+  }
+}
+
+export default MetricTypesService;

--- a/src/api/metricTypes/models.ts
+++ b/src/api/metricTypes/models.ts
@@ -1,0 +1,6 @@
+export interface IMetricType {
+  code: string;
+  description: string;
+}
+
+export type MetricTypeUpdateType = Pick<IMetricType, "description">;

--- a/src/api/sectors/models.ts
+++ b/src/api/sectors/models.ts
@@ -3,4 +3,5 @@ export interface ISector {
   name: string;
   centralizerKey: string;
   gardenId: number;
+  crops: string;
 }

--- a/src/components/Gardens/GardenDetail.tsx
+++ b/src/components/Gardens/GardenDetail.tsx
@@ -67,6 +67,7 @@ const GardenDetail = () => {
               sectorId: sector.sectorId,
               name: sector.name,
               centralizerKey: sector.centralizerKey,
+              crops: sector.crops,
               gardenId: sector.gardenId,
             };
           }),
@@ -83,6 +84,7 @@ const GardenDetail = () => {
               sectorId: sector.sectorId,
               name: sector.name,
               centralizerKey: sector.centralizerKey,
+              crops: sector.crops,
               gardenId: sector.gardenId,
             };
           }),
@@ -175,6 +177,13 @@ const GardenDetail = () => {
                     <Form.Item
                       label="Nombre"
                       name={[name, "name"]}
+                      rules={[{ required: true, message: "Campo obligatorio" }]}
+                    >
+                      <Input />
+                    </Form.Item>
+                    <Form.Item
+                      label="Cultivos"
+                      name={[name, "crops"]}
                       rules={[{ required: true, message: "Campo obligatorio" }]}
                     >
                       <Input />

--- a/src/components/Gardens/GardenDetail.tsx
+++ b/src/components/Gardens/GardenDetail.tsx
@@ -72,8 +72,7 @@ const GardenDetail = () => {
             };
           }),
         };
-        //   await GardensService.update(id, entity);
-        console.log(entity);
+        await GardensService.update(id, entity);
       } else {
         const entity: GardenAddType = {
           name: values.name,
@@ -89,12 +88,11 @@ const GardenDetail = () => {
             };
           }),
         };
-        // await GardensService.add(entity);
-        console.log(entity);
+        await GardensService.add(entity);
       }
 
       message.success("Operación exitosa");
-      // navigate(-1);
+      navigate(-1);
     } catch (error) {
       if (error.message) message.error(error.message);
     } finally {
@@ -104,7 +102,6 @@ const GardenDetail = () => {
 
   const handleCopy = async (text: string) => {
     await navigator.clipboard.writeText(text);
-    debugger;
     message.success("Copiado al portapapeles");
   };
 

--- a/src/components/MetricAcceptationRanges/MetricAcceptationRangeDetail.tsx
+++ b/src/components/MetricAcceptationRanges/MetricAcceptationRangeDetail.tsx
@@ -1,0 +1,212 @@
+import {
+  Button,
+  Card,
+  Divider,
+  Form,
+  Input,
+  InputNumber,
+  message,
+  Popconfirm,
+  Select,
+  Spin,
+} from "antd";
+import { useForm } from "antd/lib/form/Form";
+import React, { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import MetricAcceptationRangesService from "../../api/metricAcceptationRanges/MetricAcceptationRangesService";
+import {
+  IMetricAcceptationRange,
+  MetricAcceptationRangeAddType,
+  MetricAcceptationRangeUpdateType,
+} from "../../api/metricAcceptationRanges/models";
+import MetricTypesService from "../../api/metricTypes/MetricTypesService";
+import { IMetricType } from "../../api/metricTypes/models";
+import { formatMetricValue } from "../../helpers/metric-helper";
+import BackButton from "../BackButton/BackButton";
+
+interface FormValues {
+  name: string;
+  startValue: number;
+  endValue: number;
+  metricTypeCode: string;
+}
+
+const formItemLayout = {
+  wrapperCol: { xs: 24, sm: 24, md: 24, lg: 20 },
+  labelCol: { xs: 24, sm: 24, md: 24, lg: 4 },
+};
+
+const MetricAcceptationRangeDetail: React.FC = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const [form] = useForm<FormValues>();
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+
+  const [metricTypes, setMetricTypes] = useState<IMetricType[]>([]);
+
+  const [metricAcceptationRange, setMetricAcceptationRange] =
+    useState<IMetricAcceptationRange>({
+      metricAcceptationRangeId: 0,
+      name: "",
+      startValue: 0,
+      endValue: 0,
+      metricTypeCode: "",
+    });
+
+  const handleSubmit = async (values: FormValues) => {
+    try {
+      setIsSubmitting(true);
+      if (id) {
+        const entity: MetricAcceptationRangeUpdateType = {
+          metricAcceptationRangeId: +id,
+          name: values.name,
+          startValue: Number(
+            formatMetricValue(values.startValue, values.metricTypeCode)
+          ),
+          endValue: Number(
+            formatMetricValue(values.endValue, values.metricTypeCode)
+          ),
+          metricTypeCode: values.metricTypeCode,
+        };
+        await MetricAcceptationRangesService.update(id, entity);
+      } else {
+        const entity: MetricAcceptationRangeAddType = {
+          name: values.name,
+          startValue: Number(
+            formatMetricValue(values.startValue, values.metricTypeCode)
+          ),
+          endValue: Number(
+            formatMetricValue(values.endValue, values.metricTypeCode)
+          ),
+          metricTypeCode: values.metricTypeCode,
+        };
+        await MetricAcceptationRangesService.add(entity);
+      }
+      message.success("Operación exitosa");
+      navigate(-1);
+    } catch (error) {
+      if (error.message) message.error(error.message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      setIsSubmitting(true);
+      await MetricAcceptationRangesService.delete(id);
+      message.success("Operación exitosa");
+      navigate(-1);
+    } catch (error) {
+      if (error.message) message.error(error.message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  useEffect(() => {
+    const fetch = async () => {
+      try {
+        setIsLoading(true);
+        const metricTypes = await MetricTypesService.fetchAll();
+        setMetricTypes(metricTypes);
+        if (id) {
+          const metricAcceptationRange =
+            await MetricAcceptationRangesService.fetchOne(id);
+          setMetricAcceptationRange(metricAcceptationRange);
+        }
+      } catch (error) {
+        if (error.message) message.error(error.message);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetch();
+  }, [id]);
+
+  return (
+    <div className="container">
+      <Card title={<BackButton title="Rango de métrica" />}>
+        {isLoading ? (
+          <div className="loading">
+            <Spin />
+          </div>
+        ) : (
+          <Form
+            form={form}
+            {...formItemLayout}
+            onFinish={(values: FormValues) => handleSubmit(values)}
+            initialValues={id ? metricAcceptationRange : undefined}
+          >
+            <Form.Item
+              name="name"
+              label="Nombre"
+              required
+              rules={[{ required: true, message: "Complete este campo" }]}
+            >
+              <Input />
+            </Form.Item>
+            <Form.Item
+              name="startValue"
+              label="Valor inicial"
+              required
+              rules={[{ required: true, message: "Complete este campo" }]}
+            >
+              <InputNumber min={0} max={100} />
+            </Form.Item>
+            <Form.Item
+              name="endValue"
+              label="Valor final"
+              required
+              rules={[{ required: true, message: "Complete este campo" }]}
+            >
+              <InputNumber min={0} max={100} />
+            </Form.Item>
+            <Form.Item
+              name="metricTypeCode"
+              label="Tipo de métrica"
+              required
+              rules={[{ required: true, message: "Complete este campo" }]}
+            >
+              <Select
+                placeholder="Seleccione tipo de métrica"
+                optionFilterProp="children"
+              >
+                {metricTypes.map((mt) => (
+                  <Select.Option value={mt.code}>
+                    {mt.description}
+                  </Select.Option>
+                ))}
+              </Select>
+            </Form.Item>
+            <Divider />
+
+            {!!id && (
+              <Popconfirm
+                title="¿Eliminar rango de métrica?"
+                cancelText="Cancelar"
+                onConfirm={() => handleDelete(id)}
+              >
+                <Button type="primary" danger loading={isSubmitting}>
+                  Eliminar
+                </Button>
+              </Popconfirm>
+            )}
+            <Button
+              type="primary"
+              style={{ float: "right" }}
+              htmlType="submit"
+              loading={isSubmitting}
+            >
+              Guardar
+            </Button>
+          </Form>
+        )}
+      </Card>
+    </div>
+  );
+};
+
+export default MetricAcceptationRangeDetail;

--- a/src/components/MetricAcceptationRanges/MetricAcceptationRangesGrid.tsx
+++ b/src/components/MetricAcceptationRanges/MetricAcceptationRangesGrid.tsx
@@ -1,0 +1,162 @@
+import { DeleteOutlined, EditOutlined, PlusOutlined } from "@ant-design/icons";
+import { Button, Card, message, Popconfirm, Table, Tag, Tooltip } from "antd";
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import MetricAcceptationRangesService from "../../api/metricAcceptationRanges/MetricAcceptationRangesService";
+import { IMetricAcceptationRange } from "../../api/metricAcceptationRanges/models";
+import { PaginatedList } from "../../api/shared/models";
+import { URLs } from "../../config/enums";
+import {
+  createBaseGridParams,
+  GridParams,
+  ROWS_PER_PAGE,
+} from "../../helpers/grid-helper";
+import { formatMetricValueWithUnit } from "../../helpers/metric-helper";
+import { MetricAcceptationRangesData } from "../../helpers/test-data-helper";
+
+const MetricAcceptationRangesGrid: React.FC = () => {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const [gridState, setGridState] = useState<GridParams>(
+    createBaseGridParams({ sortField: "createdAt" })
+  );
+
+  const navigate = useNavigate();
+
+  const [rangesFetched, setRangesFetched] = useState<
+    PaginatedList<IMetricAcceptationRange>
+  >({
+    list: MetricAcceptationRangesData,
+    count: MetricAcceptationRangesData.length,
+  });
+
+  const columns = [
+    { title: "Nombre", dataIndex: "name" },
+    {
+      title: "Valor inicial",
+      align: "center" as "center",
+      dataIndex: "startValue",
+      render: (cell: number, row: IMetricAcceptationRange) =>
+        formatMetricValueWithUnit(cell, row.metricTypeCode),
+    },
+    {
+      title: "Valor final",
+      align: "center" as "center",
+      dataIndex: "endValue",
+      render: (cell: number, row: IMetricAcceptationRange) =>
+        formatMetricValueWithUnit(cell, row.metricTypeCode),
+    },
+
+    {
+      title: "Fecha de creación",
+      dataIndex: "createdAt",
+    },
+    {
+      title: "Tipo de métrica",
+      dataIndex: "metricTypeDescription",
+      render: (cell: any) => <Tag>{cell}</Tag>,
+    },
+    {
+      title: "Acciones",
+      width: 120,
+      render: (cell: any, row: IMetricAcceptationRange) => (
+        <>
+          <Tooltip title="Editar">
+            <Button
+              style={{ marginRight: 10 }}
+              type="default"
+              icon={<EditOutlined />}
+              onClick={() =>
+                navigate(
+                  `${URLs.METRIC_ACCEPTATION_RANGES}${URLs.DETAIL.replace(
+                    ":id",
+                    row.metricAcceptationRangeId.toString()
+                  )}`
+                )
+              }
+            />
+          </Tooltip>
+          <Tooltip title="Eliminar">
+            <Popconfirm
+              placement="right"
+              cancelText="Cancelar"
+              title="¿Eliminar Rango de métrica?"
+              onConfirm={() =>
+                handleDelete(row.metricAcceptationRangeId.toString())
+              }
+              cancelButtonProps={{ loading: isLoading }}
+            >
+              <Button danger type="primary" icon={<DeleteOutlined />} />
+            </Popconfirm>
+          </Tooltip>
+        </>
+      ),
+    },
+  ];
+
+  const handleDelete = async (id: string) => {
+    try {
+      setIsLoading(true);
+      await MetricAcceptationRangesService.delete(id);
+      message.success("Operación exitosa");
+      setGridState({ ...gridState });
+    } catch (error) {
+      if (error.message) message.error(error.message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    const fetchMetricAcceptationRanges = async () => {
+      try {
+        setIsLoading(true);
+        const response = await MetricAcceptationRangesService.fetchList(
+          gridState
+        );
+        setRangesFetched(response);
+      } catch (error) {
+        if (error.message) message.error(error.message);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchMetricAcceptationRanges();
+  }, [gridState]);
+
+  return (
+    <div className="container">
+      <Card
+        title={
+          <>
+            <span>Rangos de métrica</span>
+            <Tooltip title="Añadir">
+              <Button
+                type="primary"
+                icon={<PlusOutlined />}
+                shape="circle"
+                style={{ float: "right" }}
+                onClick={() =>
+                  navigate(`${URLs.METRIC_ACCEPTATION_RANGES}${URLs.NEW}`)
+                }
+              />
+            </Tooltip>
+          </>
+        }
+      >
+        <Table
+          rowKey="metricAcceptationRangeId"
+          loading={isLoading}
+          dataSource={rangesFetched.list}
+          columns={columns}
+          bordered
+          pagination={{ pageSize: ROWS_PER_PAGE, hideOnSinglePage: true }}
+          scroll={{ x: 1024 }}
+        />
+      </Card>
+    </div>
+  );
+};
+
+export default MetricAcceptationRangesGrid;

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -8,4 +8,6 @@ export enum API {
   USERS = "/users",
   ROLES = "/roles",
   GARDENS = "/gardens",
+  METRIC_ACCEPTATION_RANGES = "/metric-acceptation-ranges",
+  METRIC_TYPES = "/metric-types",
 }

--- a/src/config/enums.ts
+++ b/src/config/enums.ts
@@ -7,6 +7,7 @@ export enum URLs {
   USERS = "/usuarios",
   ROLES = "/roles",
   GARDENS = "/huertas",
+  METRIC_ACCEPTATION_RANGES = "/rangos-metricas",
   PROFILE = "/perfil",
 
   // Common routes

--- a/src/helpers/menu-helper.tsx
+++ b/src/helpers/menu-helper.tsx
@@ -28,6 +28,11 @@ export const MenuItems: MenuItem[] = [
         label: "Mis huertas",
         roles: [RolesEnum.GARDEN_MANAGER],
       },
+      {
+        key: URLs.METRIC_ACCEPTATION_RANGES,
+        label: "Rangos de métrica",
+        roles: [RolesEnum.GARDEN_MANAGER],
+      },
     ],
   },
   {

--- a/src/helpers/metric-helper.ts
+++ b/src/helpers/metric-helper.ts
@@ -1,0 +1,18 @@
+export const formatMetricValueWithUnit = (
+  value: number,
+  metricTypeCode: string
+) => {
+  if (!metricTypeCode) return value;
+  if (metricTypeCode.includes("TEMPERATURA"))
+    return `${formatMetricValue(value, metricTypeCode)}°C`;
+  if (metricTypeCode.includes("HUMEDAD"))
+    return `${formatMetricValue(value, metricTypeCode)}%`;
+};
+
+export const formatMetricValue = (value: number, metricTypeCode: string) => {
+  if (!metricTypeCode) return value;
+  if (metricTypeCode.includes("TEMPERATURA"))
+    return `${+value.toFixed(1).replace(/[.,]0$/, "")}`;
+  if (metricTypeCode.includes("HUMEDAD"))
+    return `${+value.toFixed(2).replace(/[.,]00$/, "")}`;
+};

--- a/src/helpers/test-data-helper.ts
+++ b/src/helpers/test-data-helper.ts
@@ -1,0 +1,44 @@
+import { IMetricAcceptationRange } from "../api/metricAcceptationRanges/models";
+
+export const MetricAcceptationRangesData: IMetricAcceptationRange[] = [
+  {
+    metricAcceptationRangeId: 1,
+    name: "Rango 1",
+    startValue: 35.2,
+    endValue: 35.2,
+    metricTypeCode: "HUMEDAD_AMBIENTE",
+    metricTypeDescription: "Humedad del ambiente",
+  },
+  {
+    metricAcceptationRangeId: 2,
+    name: "Rango 2",
+    startValue: 10.149,
+    endValue: 10,
+    metricTypeCode: "HUMEDAD_SUELO",
+    metricTypeDescription: "Humedad del suelo",
+  },
+  {
+    metricAcceptationRangeId: 3,
+    name: "Rango 3",
+    startValue: 25.1,
+    endValue: 35.4,
+    metricTypeCode: "TEMPERATURA_AMBIENTE",
+    metricTypeDescription: "Temperatura ambiente",
+  },
+  {
+    metricAcceptationRangeId: 4,
+    name: "Rango 4",
+    startValue: 15,
+    endValue: 20,
+    metricTypeCode: "HUMEDAD_AMBIENTE",
+    metricTypeDescription: "Humedad del ambiente",
+  },
+  {
+    metricAcceptationRangeId: 5,
+    name: "Rango 5",
+    startValue: 35,
+    endValue: 37,
+    metricTypeCode: "TEMPERATURA_AMBIENTE",
+    metricTypeDescription: "Temperatura ambiente",
+  },
+];

--- a/src/layout/AppRoutes.tsx
+++ b/src/layout/AppRoutes.tsx
@@ -11,6 +11,7 @@ import NotFoundPage from "../pages/NotFoundPage";
 import LogoutPage from "../pages/LogoutPage";
 import PublicRoute from "../components/PublicRoute/PublicRoute";
 import AppLayout from "./AppLayout";
+import MetricAcceptationRangesPage from "../pages/MetricAcceptationRangesPage";
 
 const AppRoutes: React.FC = () => {
   return (
@@ -54,6 +55,17 @@ const AppRoutes: React.FC = () => {
             <AppLayout>
               <LoggedInRoute>
                 <GardensPage />
+              </LoggedInRoute>
+            </AppLayout>
+          }
+        />
+
+        <Route
+          path={`${URLs.METRIC_ACCEPTATION_RANGES}/*`}
+          element={
+            <AppLayout>
+              <LoggedInRoute>
+                <MetricAcceptationRangesPage />
               </LoggedInRoute>
             </AppLayout>
           }

--- a/src/pages/MetricAcceptationRangesPage.tsx
+++ b/src/pages/MetricAcceptationRangesPage.tsx
@@ -1,0 +1,41 @@
+import { Route, Routes } from "react-router-dom";
+import { RolesEnum } from "../api/roles/enum";
+import AuthorizedRoute from "../components/AuthorizedRoute/AuthorizedRoute";
+import MetricAcceptationRangeDetail from "../components/MetricAcceptationRanges/MetricAcceptationRangeDetail";
+import MetricAcceptationRangesGrid from "../components/MetricAcceptationRanges/MetricAcceptationRangesGrid";
+import { URLs } from "../config/enums";
+
+const MetricAcceptationRangesPage: React.FC = () => {
+  return (
+    <Routes>
+      <Route
+        path={URLs.ROOT}
+        element={
+          <AuthorizedRoute roles={[RolesEnum.GARDEN_MANAGER]}>
+            <MetricAcceptationRangesGrid />
+          </AuthorizedRoute>
+        }
+      />
+
+      <Route
+        path={URLs.NEW}
+        element={
+          <AuthorizedRoute roles={[RolesEnum.GARDEN_MANAGER]}>
+            <MetricAcceptationRangeDetail />
+          </AuthorizedRoute>
+        }
+      />
+
+      <Route
+        path={URLs.DETAIL}
+        element={
+          <AuthorizedRoute roles={[RolesEnum.GARDEN_MANAGER]}>
+            <MetricAcceptationRangeDetail />
+          </AuthorizedRoute>
+        }
+      />
+    </Routes>
+  );
+};
+
+export default MetricAcceptationRangesPage;


### PR DESCRIPTION
** Implement MetricAcceptationRanges CRUD **
- Add Route / Page / Grid / Detail / Service / API route  / Models
- Add test data helper, metric helper
- Add Menu option 

** MetricType related implementations **
- Add Models / Service 

** Sector related fixes **
- Fix missing 'name' prop in GardenDetail sectors list